### PR TITLE
Fix build push authentication errors

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -18,23 +18,18 @@ env:
   IMAGE_PREFIX: ${{ github.repository }}/
 
 jobs:
-  login:
+  build-push-backend:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-  build-push-backend:
-    runs-on: ubuntu-latest
-    needs: login
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Compute image repo base (lowercase)
         run: |
           echo "IMAGE_REPO_BASE=$(echo "${{ github.repository_owner }}/${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
@@ -48,11 +43,16 @@ jobs:
 
   build-push-emotion:
     runs-on: ubuntu-latest
-    needs: login
     steps:
       - uses: actions/checkout@v4
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Compute image repo base (lowercase)
         run: |
           echo "IMAGE_REPO_BASE=$(echo "${{ github.repository_owner }}/${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
@@ -66,11 +66,16 @@ jobs:
 
   build-push-recommendation:
     runs-on: ubuntu-latest
-    needs: login
     steps:
       - uses: actions/checkout@v4
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Compute image repo base (lowercase)
         run: |
           echo "IMAGE_REPO_BASE=$(echo "${{ github.repository_owner }}/${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV


### PR DESCRIPTION
Add `docker/login-action` to each build-push job to resolve 403 Forbidden errors when pushing to GHCR.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5973f40-f9b0-4f51-8a13-922eced43136">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5973f40-f9b0-4f51-8a13-922eced43136">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

