### PR TITLE
Install dependencies and build image

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -18,21 +18,16 @@ env:
   IMAGE_PREFIX: ${{ github.repository }}/
 
 jobs:
-  login:
+  build-push-backend:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-  build-push-backend:
-    runs-on: ubuntu-latest
-    needs: login
-    steps:
-      - uses: actions/checkout@v4
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       - name: Compute image repo base (lowercase)
@@ -48,9 +43,14 @@ jobs:
 
   build-push-emotion:
     runs-on: ubuntu-latest
-    needs: login
     steps:
       - uses: actions/checkout@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       - name: Compute image repo base (lowercase)
@@ -66,9 +66,14 @@ jobs:
 
   build-push-recommendation:
     runs-on: ubuntu-latest
-    needs: login
     steps:
       - uses: actions/checkout@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       - name: Compute image repo base (lowercase)


### PR DESCRIPTION
Add GHCR login to each build-and-push job and remove the separate login job.

The previous workflow had a dedicated `login` job, but Docker login credentials do not persist across separate jobs in GitHub Actions. This led to a "failed to fetch anonymous token: 403 Forbidden" error when subsequent build-and-push jobs attempted to push to GHCR anonymously. Moving the login step into each build job ensures proper authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-29ee284c-14bc-482e-ad06-0dc3a99f1913">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29ee284c-14bc-482e-ad06-0dc3a99f1913">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

