### PR TITLE
Fix mermaid diagram parsing error

### DIFF
--- a/Docs/DataFlowDiagram.md
+++ b/Docs/DataFlowDiagram.md
@@ -5,7 +5,7 @@ Scope: End-user mobile/desktop client (Unity), secure backend (Azure), external 
 ```mermaid
 flowchart LR
   %% Trust Boundary: Client Device
-  subgraph TB1[Client Device (Trust Boundary)]
+  subgraph TB1[Client Device - Trust Boundary]
     U[Unity Client App]
     Mic[(Microphone Input)]
     Spk((Speaker Output))
@@ -13,12 +13,12 @@ flowchart LR
   end
 
   %% Trust Boundary: Identity
-  subgraph TB2[Identity & Access]
+  subgraph TB2[Identity and Access]
     B2C[Azure AD B2C (OIDC)]
   end
 
   %% Trust Boundary: Secure Backend (VNet + Private Endpoints)
-  subgraph TB3[Secure Backend (VNet)]
+  subgraph TB3[Secure Backend - VNet]
     APIM[API Management (WAF/Rate Limit)]
     API[App Service API]
     KV[Key Vault]
@@ -36,7 +36,7 @@ flowchart LR
   end
 
   %% Trust Boundary: Analytics / Admin
-  subgraph TB5[Analytics & Admin]
+  subgraph TB5[Analytics and Admin]
     BI[Analytics/Dashboard]
     ADMIN[Admin/Clinical Portal]
   end


### PR DESCRIPTION
Fix Mermaid diagram parse errors by updating subgraph titles for GitHub compatibility.

Parentheses and ampersands in subgraph titles were causing GitHub's Mermaid renderer to fail, so they have been replaced with hyphens and 'and' respectively.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e44826e-cd7f-4f3b-95e1-8121209e0053">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e44826e-cd7f-4f3b-95e1-8121209e0053">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

